### PR TITLE
A lot of shop code

### DIFF
--- a/src/main/java/io/luna/game/model/item/shop/Shop.java
+++ b/src/main/java/io/luna/game/model/item/shop/Shop.java
@@ -522,12 +522,6 @@ public final class Shop {
             double netPriceMod = (endingPriceMod + startingPriceMod);
             valueMod += netPriceMod * (double)(netIndex / 2) + (netIndex % 2 * 0.5 * netPriceMod);
             totalMoney = (int) (value * valueMod);
-            // This is an incredibly fast approximation of rounding for items with an average value less than 1.
-            // Example: selling 6 items that cost 1.3, 1.2, 1.1, 1.0, 0.9, 0.8 coins respectively. The expected output is 4.
-            // Since you are selling 4 items above the 1 coin threshold.
-            // The output this provides is 6.3 - 2 = 4.
-            // For items worth more than 1, this will increase the rounding precision when buying more than 1 item at a time.
-            totalMoney = (int) ((value * valueMod) - ((totalMoney % amountSold) / 2));
         }
         return totalMoney;
     }

--- a/src/main/java/io/luna/game/model/item/shop/Shop.java
+++ b/src/main/java/io/luna/game/model/item/shop/Shop.java
@@ -26,56 +26,6 @@ import java.util.Set;
  */
 public final class Shop {
 
-    /**
-     * The number formatter. Uses the UK locale.
-     */
-    private static final NumberFormat FORMAT = NumberFormat.getInstance(Locale.UK);
-
-    /**
-     * The world instance.
-     */
-    private final World world;
-
-    /**
-     * The shop name.
-     */
-    private final String name;
-
-    /**
-     * The shop items.
-     */
-    private final ItemContainer container = new ItemContainer(40, StackPolicy.ALWAYS, 3900);
-
-    /**
-     * The restock policy.
-     */
-    private final RestockPolicy restockPolicy;
-
-    /**
-     * The sell policy.
-     */
-    private final BuyPolicy buyPolicy;
-
-    /**
-     * The currency used to buy items.
-     */
-    private final Currency currency;
-
-    /**
-     * The players viewing this shop.
-     */
-    private final Set<Player> viewing = new HashSet<>();
-
-    /**
-     * A dictionary of original item amounts. {@link OptionalInt#empty()} indicates an empty slot.
-     */
-    private final OptionalInt[] amountMap = new OptionalInt[40];
-
-    /**
-     * The restock task.
-     */
-    private RestockTask restockTask;
-
     // "Magic numbers" for the buy and sell functions.
     // Can be configured before compiling to change how shops price goods.
 
@@ -144,6 +94,56 @@ public final class Shop {
      * is slightly more authentic (but perhaps less desirable) to the original game.
      */
     private static final boolean PERFECT_PRECISION_TRANSACTIONS = false;
+
+    /**
+     * The number formatter. Uses the UK locale.
+     */
+    private static final NumberFormat FORMAT = NumberFormat.getInstance(Locale.UK);
+
+    /**
+     * The world instance.
+     */
+    private final World world;
+
+    /**
+     * The shop name.
+     */
+    private final String name;
+
+    /**
+     * The shop items.
+     */
+    private final ItemContainer container = new ItemContainer(40, StackPolicy.ALWAYS, 3900);
+
+    /**
+     * The restock policy.
+     */
+    private final RestockPolicy restockPolicy;
+
+    /**
+     * The sell policy.
+     */
+    private final BuyPolicy buyPolicy;
+
+    /**
+     * The currency used to buy items.
+     */
+    private final Currency currency;
+
+    /**
+     * The players viewing this shop.
+     */
+    private final Set<Player> viewing = new HashSet<>();
+
+    /**
+     * A dictionary of original item amounts. {@link OptionalInt#empty()} indicates an empty slot.
+     */
+    private final OptionalInt[] amountMap = new OptionalInt[40];
+
+    /**
+     * The restock task.
+     */
+    private RestockTask restockTask;
 
 
     /**


### PR DESCRIPTION
Full change-log:

Closes #153.
Moves magic variables outside the buy function because they are used by both the buy and sell function, and documents them more completely so they can be edited.
Adds support for high volume/common items which do not change in price as rapidly as normal items (only 0.1% at a time instead of 2%.) Items with a stock over 20 are marked as common.
Adds support for rounding each item bought/sold, instead of only rounding at the end. This is more accurate to how the original game did it, but isn't enabled by default because it's more computationally expensive (O(n) vs O(1) for n items, which is fine for 10 items but becomes a problem if you add "sell x items") and makes it more annoying to sell and buy low value items in high quantities like runes while offering no benefits besides authenticity.
Rounds all prices, both bought and sold, down at the end, as the game does.
Stops shopkeepers from selling items worth more than 0 gold for 0 gold. The player still can though.
Simplifies the calculateBuyValue code.