### PR TITLE
Fixed build by bumping Kotlin minor version to 11

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    val kotlinVersion = "1.3.11"
+    val kotlinVersion = "1.3.21"
     val jfxVersion = "0.0.8"
 
     java

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    val kotlinVersion = "1.3.50"
+    val kotlinVersion = "1.3.11"
     val jfxVersion = "0.0.8"
 
     java


### PR DESCRIPTION
ran into
```java.lang.ClassNotFoundException: org.jetbrains.kotlin.scripting.compiler.plugin.repl.GenericReplCompiler```

when running for the first time, bumping the minor version down to 11 fixed this.