### PR TITLE
Make-over mage plugin

### DIFF
--- a/plugins/world/npc/makeOver/makeOver.kts
+++ b/plugins/world/npc/makeOver/makeOver.kts
@@ -1,0 +1,25 @@
+package world.npc.makeOver
+
+import api.predef.*
+import io.luna.game.event.impl.ServerLaunchEvent
+import io.luna.game.model.mob.PlayerAppearance
+
+/**
+ * Dialogue for "Talk" option.
+ */
+npc1(599) {
+    plr.newDialogue()
+            .npc(npc.id, "Would you like to change your appearance?")
+            .options(
+                    "Yes", {plr.interfaces.open(PlayerAppearance.DesignPlayerInterface()) },
+                    "No", {}).open()
+}
+
+/**
+ * Spawn make-over mage NPC.
+ */
+on(ServerLaunchEvent::class) {
+    world.addNpc(id = 599,
+                 x = 3092,
+                 y = 3250)
+}

--- a/plugins/world/npc/makeOver/plugin.build.kts
+++ b/plugins/world/npc/makeOver/plugin.build.kts
@@ -1,0 +1,13 @@
+package world.npc.makeOver
+
+import api.bootstrap.plugin
+
+plugin {
+    name = "Make-over mage"
+    description =
+        """
+        A plugin that enables a make-over mage at the player spawn location.
+        """
+    version = "1.0"
+    authors += "searledan"
+}

--- a/plugins/world/npc/makeOver/plugin.toml
+++ b/plugins/world/npc/makeOver/plugin.toml
@@ -1,0 +1,7 @@
+[metadata]
+name = "Make-over mage"
+description = "A plugin that enables a make-over mage at the player spawn location."
+version = "1.0"
+authors = [
+  "searledan"
+]

--- a/plugins/world/npc/makeOver/plugin.toml
+++ b/plugins/world/npc/makeOver/plugin.toml
@@ -1,7 +1,0 @@
-[metadata]
-name = "Make-over mage"
-description = "A plugin that enables a make-over mage at the player spawn location."
-version = "1.0"
-authors = [
-  "searledan"
-]


### PR DESCRIPTION
Added a "Make-over mage" between the "Shopkeeper" and "Tanner" NPC's.

The "Make-over mage" creates a yes or no dialogue confirming if the user wants to change their appearance:

- Yes, opens the design player interface.
- No, does nothing.

Issue: #105 