### PR TITLE
Extract and expose DefinitionRepository implementations

### DIFF
--- a/src/main/java/io/luna/game/model/def/ArrayDefinitionRepository.java
+++ b/src/main/java/io/luna/game/model/def/ArrayDefinitionRepository.java
@@ -1,0 +1,43 @@
+package io.luna.game.model.def;
+
+import com.google.common.collect.Iterators;
+
+import java.util.Iterator;
+import java.util.Optional;
+
+/**
+ * An implementation of {@link DefinitionRepository} that is backed internally by an array.
+ */
+public final class ArrayDefinitionRepository<T extends Definition> extends DefinitionRepository<T> {
+
+    /**
+     * An array of definitions.
+     */
+    public final T[] definitions;
+
+    /**
+     * Creates a new {@link ArrayDefinitionRepository}.
+     *
+     * @param length
+     *         The length of the backing array.
+     */
+    @SuppressWarnings("unchecked")
+    public ArrayDefinitionRepository(int length) {
+        definitions = (T[]) new Definition[length];
+    }
+
+    @Override
+    void put(int id, T definition) {
+        definitions[id] = definition;
+    }
+
+    @Override
+    public Optional<T> get(int id) {
+        return Optional.ofNullable(definitions[id]);
+    }
+
+    @Override
+    public Iterator<T> newIterator() {
+        return Iterators.forArray(definitions);
+    }
+}

--- a/src/main/java/io/luna/game/model/def/DefinitionRepository.java
+++ b/src/main/java/io/luna/game/model/def/DefinitionRepository.java
@@ -5,8 +5,6 @@ import com.google.common.collect.UnmodifiableIterator;
 
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
@@ -26,32 +24,6 @@ import static com.google.common.base.Preconditions.checkState;
  * @author lare96 <http://github.com/lare96>
  */
 public abstract class DefinitionRepository<T extends Definition> implements Iterable<T> {
-
-    /**
-     * An implementation of {@link DefinitionRepository} that is backed internally by a {@link LinkedHashMap}.
-     */
-    static final class MapDefinitionRepository<V extends Definition> extends DefinitionRepository<V> {
-
-        /**
-         * A map of definitions.
-         */
-        private final Map<Integer, V> definitions = new LinkedHashMap<>();
-
-        @Override
-        void put(int id, V definition) {
-            definitions.put(id, definition);
-        }
-
-        @Override
-        public Optional<V> get(int id) {
-            return Optional.ofNullable(definitions.get(id));
-        }
-
-        @Override
-        public Iterator<V> newIterator() {
-            return definitions.values().iterator();
-        }
-    }
 
     /**
      * If this repository is read-only.

--- a/src/main/java/io/luna/game/model/def/DefinitionRepository.java
+++ b/src/main/java/io/luna/game/model/def/DefinitionRepository.java
@@ -28,42 +28,6 @@ import static com.google.common.base.Preconditions.checkState;
 public abstract class DefinitionRepository<T extends Definition> implements Iterable<T> {
 
     /**
-     * An implementation of {@link DefinitionRepository} that is backed internally by an array.
-     */
-    static final class ArrayDefinitionRepository<T extends Definition> extends DefinitionRepository<T> {
-
-        /**
-         * An array of definitions.
-         */
-        public final T[] definitions;
-
-        /**
-         * Creates a new {@link ArrayDefinitionRepository}.
-         *
-         * @param length The length of the backing array.
-         */
-        @SuppressWarnings("unchecked")
-        public ArrayDefinitionRepository(int length) {
-            definitions = (T[]) new Definition[length];
-        }
-
-        @Override
-        void put(int id, T definition) {
-            definitions[id] = definition;
-        }
-
-        @Override
-        public Optional<T> get(int id) {
-            return Optional.ofNullable(definitions[id]);
-        }
-
-        @Override
-        public Iterator<T> newIterator() {
-            return Iterators.forArray(definitions);
-        }
-    }
-
-    /**
      * An implementation of {@link DefinitionRepository} that is backed internally by a {@link LinkedHashMap}.
      */
     static final class MapDefinitionRepository<V extends Definition> extends DefinitionRepository<V> {

--- a/src/main/java/io/luna/game/model/def/EquipmentDefinition.java
+++ b/src/main/java/io/luna/game/model/def/EquipmentDefinition.java
@@ -3,7 +3,6 @@ package io.luna.game.model.def;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.JsonObject;
-import io.luna.game.model.def.DefinitionRepository.MapDefinitionRepository;
 import io.luna.game.model.mob.Mob;
 import io.luna.game.model.mob.Player;
 import io.luna.game.model.mob.Skill;

--- a/src/main/java/io/luna/game/model/def/ItemDefinition.java
+++ b/src/main/java/io/luna/game/model/def/ItemDefinition.java
@@ -1,7 +1,6 @@
 package io.luna.game.model.def;
 
 import com.google.common.collect.ImmutableList;
-import io.luna.game.model.def.DefinitionRepository.ArrayDefinitionRepository;
 
 import java.util.OptionalInt;
 

--- a/src/main/java/io/luna/game/model/def/MapDefinitionRepository.java
+++ b/src/main/java/io/luna/game/model/def/MapDefinitionRepository.java
@@ -1,0 +1,32 @@
+package io.luna.game.model.def;
+
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * An implementation of {@link DefinitionRepository} that is backed internally by a {@link LinkedHashMap}.
+ */
+public final class MapDefinitionRepository<V extends Definition> extends DefinitionRepository<V> {
+
+    /**
+     * A map of definitions.
+     */
+    private final Map<Integer, V> definitions = new LinkedHashMap<>();
+
+    @Override
+    void put(int id, V definition) {
+        definitions.put(id, definition);
+    }
+
+    @Override
+    public Optional<V> get(int id) {
+        return Optional.ofNullable(definitions.get(id));
+    }
+
+    @Override
+    public Iterator<V> newIterator() {
+        return definitions.values().iterator();
+    }
+}

--- a/src/main/java/io/luna/game/model/def/NpcCombatDefinition.java
+++ b/src/main/java/io/luna/game/model/def/NpcCombatDefinition.java
@@ -1,7 +1,5 @@
 package io.luna.game.model.def;
 
-import io.luna.game.model.def.DefinitionRepository.MapDefinitionRepository;
-
 import java.util.Arrays;
 
 /**

--- a/src/main/java/io/luna/game/model/def/NpcDefinition.java
+++ b/src/main/java/io/luna/game/model/def/NpcDefinition.java
@@ -1,7 +1,6 @@
 package io.luna.game.model.def;
 
 import com.google.common.collect.ImmutableList;
-import io.luna.game.model.def.DefinitionRepository.ArrayDefinitionRepository;
 
 /**
  * A definition model describing a non-player mob.

--- a/src/main/java/io/luna/game/model/def/ObjectDefinition.java
+++ b/src/main/java/io/luna/game/model/def/ObjectDefinition.java
@@ -1,7 +1,6 @@
 package io.luna.game.model.def;
 
 import com.google.common.collect.ImmutableList;
-import io.luna.game.model.def.DefinitionRepository.ArrayDefinitionRepository;
 
 /**
  * A definition model describing in-game objects.

--- a/src/test/java/io/luna/game/model/def/ArrayDefinitionRepositoryTest.java
+++ b/src/test/java/io/luna/game/model/def/ArrayDefinitionRepositoryTest.java
@@ -1,0 +1,40 @@
+package io.luna.game.model.def;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ArrayDefinitionRepositoryTest {
+
+    private ArrayDefinitionRepository<MockDefinition> repository;
+
+    @Test
+    void testGetByIndex() {
+        repository = new ArrayDefinitionRepository<>(1);
+        repository.put(0, new MockDefinition(1));
+
+        assertTrue(repository.get(0).isPresent()); // get def by index
+    }
+
+    @Test
+    void testLookupById() {
+        repository = new ArrayDefinitionRepository<>(1);
+        repository.put(0, new MockDefinition(1));
+
+        assertTrue(repository.lookup(def -> def.getId() == 1).isPresent()); // get def by id
+    }
+
+    @Test
+    void testPut_withDuplicateValue() {
+        repository = new ArrayDefinitionRepository<>(2);
+
+        var mock = new MockDefinition(1);
+        repository.put(0, mock); // insert into index 0
+        repository.put(1, mock); // insert into index 1
+
+        var first = repository.get(0);
+        var second = repository.get(1);
+
+        assertEquals(first, second);
+    }
+}

--- a/src/test/java/io/luna/game/model/def/DefinitionRepositoryTest.java
+++ b/src/test/java/io/luna/game/model/def/DefinitionRepositoryTest.java
@@ -15,7 +15,9 @@ final class DefinitionRepositoryTest {
 
     @Test
     void testLock() {
+        // here we mock the abstract class to test functionality that exists within all implementations
         var repository = mock(DefinitionRepository.class, Mockito.CALLS_REAL_METHODS);
+
         repository.lock();
 
         var definition = new MockDefinition(1);

--- a/src/test/java/io/luna/game/model/def/DefinitionRepositoryTest.java
+++ b/src/test/java/io/luna/game/model/def/DefinitionRepositoryTest.java
@@ -1,7 +1,5 @@
 package io.luna.game.model.def;
 
-import io.luna.game.model.def.DefinitionRepository.ArrayDefinitionRepository;
-import io.luna.game.model.def.DefinitionRepository.MapDefinitionRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/io/luna/game/model/def/DefinitionRepositoryTest.java
+++ b/src/test/java/io/luna/game/model/def/DefinitionRepositoryTest.java
@@ -1,11 +1,10 @@
 package io.luna.game.model.def;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link DefinitionRepository}.
@@ -14,25 +13,12 @@ import static org.mockito.Mockito.when;
  */
 final class DefinitionRepositoryTest {
 
-    Definition def;
-
-    @BeforeEach
-    void initDefinition() {
-        def = mock(Definition.class);
-        when(def.getId()).thenReturn(1);
-    }
-
     @Test
-    void lockedArrayRepository() {
-        var repository = new ArrayDefinitionRepository<>(0);
+    void testLock() {
+        var repository = mock(DefinitionRepository.class, Mockito.CALLS_REAL_METHODS);
         repository.lock();
-        assertThrows(IllegalStateException.class, () -> repository.storeDefinition(def));
-    }
 
-    @Test
-    void lockedMapRepository() {
-        var repository = new MapDefinitionRepository<>();
-        repository.lock();
-        assertThrows(IllegalStateException.class, () -> repository.storeDefinition(def));
+        var definition = new MockDefinition(1);
+        assertThrows(IllegalStateException.class, () -> repository.storeDefinition(definition));
     }
 }

--- a/src/test/java/io/luna/game/model/def/MockDefinition.java
+++ b/src/test/java/io/luna/game/model/def/MockDefinition.java
@@ -1,0 +1,23 @@
+package io.luna.game.model.def;
+
+/**
+ * A mock definition for testing purposes.
+ */
+class MockDefinition implements Definition {
+
+    private int id;
+
+    MockDefinition(int id) {
+        this.id = id;
+    }
+
+    /**
+     * Returns the identifier of this definition.
+     *
+     * @return The identifier.
+     */
+    @Override
+    public int getId() {
+        return id;
+    }
+}


### PR DESCRIPTION
# Purpose
Extracts implementations of DefinitionRepository to their own separate class files, and makes them public.
Closes #206 

# Result
## Before
```java
DefinitionRepository.ArrayDefinitionRepository<Definition> arrayRepository = new DefinitionRepository.ArrayDefinitionRepository<>(0);

DefinitionRepository.MapDefinitionRepository<Definition> mapRepository = new DefinitionRepository.MapDefinitionRepository<>(0);
```
## After
```java
ArrayDefinitionRepository<Definition> repository = new ArrayDefinitionRepository<>(0);
MapDefinitionRepository<Definition> repository = new MapDefinitionRepository<>(0);
```