### PR TITLE
refactor(root): Introduce files module

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,3 @@
-
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -12,13 +11,19 @@ plugins {
     id("org.openjfx.javafxplugin") version jfxVersion
 }
 
-repositories {
-    jcenter()
+allprojects {
+    group = "luna"
+    version = "1.0"
+
+    repositories {
+        jcenter()
+    }
 }
 
 val junitVersion: String by project
 
 dependencies {
+    implementation(project("files"))
     implementation("com.google.code.gson:gson:2.8.5")
     implementation("org.apache.logging.log4j:log4j-core:2.11.1")
     implementation("org.apache.logging.log4j:log4j-api:2.11.1")
@@ -43,16 +48,8 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
 }
 
-group = "luna"
-version = "1.0"
-
 application {
     mainClassName = "io.luna.Luna"
-}
-
-java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
 }
 
 sourceSets {
@@ -70,7 +67,6 @@ javafx {
 
 tasks.withType<JavaCompile> {
     options.compilerArgs = MutableList(1) { "-Xlint:unchecked" }
-    options.encoding = "UTF-8"
 }
 
 tasks.withType<KotlinCompile>().all {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    java
+}
+
+allprojects {
+    java {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
+    tasks.withType<JavaCompile> {
+        options.encoding = "UTF-8"
+    }
+}
+

--- a/files/build.gradle.kts
+++ b/files/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+    `java-library`
+}
+
+dependencies {
+    implementation("com.google.code.gson:gson:2.8.5")
+    implementation("com.google.guava:guava:27.0.1-jre")
+}

--- a/files/src/main/java/io/luna/files/AbstractFileParser.java
+++ b/files/src/main/java/io/luna/files/AbstractFileParser.java
@@ -1,4 +1,4 @@
-package io.luna.util.parser;
+package io.luna.files;
 
 import com.google.common.collect.ImmutableList;
 

--- a/files/src/main/java/io/luna/files/AbstractJsonFileParser.java
+++ b/files/src/main/java/io/luna/files/AbstractJsonFileParser.java
@@ -1,4 +1,4 @@
-package io.luna.util.parser;
+package io.luna.files;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;

--- a/files/src/main/java/io/luna/files/AbstractNewLineFileParser.java
+++ b/files/src/main/java/io/luna/files/AbstractNewLineFileParser.java
@@ -1,4 +1,4 @@
-package io.luna.util.parser;
+package io.luna.files;
 
 import java.io.BufferedReader;
 import java.util.Scanner;

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,3 +3,5 @@
  */
 
 rootProject.name = "luna"
+include("network")
+include("files")

--- a/src/main/java/io/luna/util/parser/impl/BlacklistFileParser.java
+++ b/src/main/java/io/luna/util/parser/impl/BlacklistFileParser.java
@@ -3,7 +3,7 @@ package io.luna.util.parser.impl;
 import com.google.common.collect.ImmutableList;
 import com.google.common.net.InetAddresses;
 import io.luna.net.LunaChannelFilter;
-import io.luna.util.parser.AbstractNewLineFileParser;
+import io.luna.files.AbstractNewLineFileParser;
 
 /**
  * A {@link AbstractNewLineFileParser} implementation that parses blacklisted addresses.

--- a/src/main/java/io/luna/util/parser/impl/EquipmentDefinitionFileParser.java
+++ b/src/main/java/io/luna/util/parser/impl/EquipmentDefinitionFileParser.java
@@ -5,7 +5,7 @@ import com.google.gson.JsonObject;
 import io.luna.game.model.def.EquipmentDefinition;
 import io.luna.game.model.def.EquipmentDefinition.Requirement;
 import io.luna.util.GsonUtils;
-import io.luna.util.parser.AbstractJsonFileParser;
+import io.luna.files.AbstractJsonFileParser;
 
 /**
  * A {@link AbstractJsonFileParser} implementation that reads equipment definitions.

--- a/src/main/java/io/luna/util/parser/impl/ItemDefinitionFileParser.java
+++ b/src/main/java/io/luna/util/parser/impl/ItemDefinitionFileParser.java
@@ -4,7 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.gson.JsonObject;
 import io.luna.game.model.def.ItemDefinition;
 import io.luna.util.GsonUtils;
-import io.luna.util.parser.AbstractJsonFileParser;
+import io.luna.files.AbstractJsonFileParser;
 
 /**
  * A {@link AbstractJsonFileParser} implementation that reads item definitions.

--- a/src/main/java/io/luna/util/parser/impl/MessageRepositoryFileParser.java
+++ b/src/main/java/io/luna/util/parser/impl/MessageRepositoryFileParser.java
@@ -7,7 +7,7 @@ import io.luna.game.model.mob.Player;
 import io.luna.net.msg.GameMessage;
 import io.luna.net.msg.GameMessageReader;
 import io.luna.net.msg.GameMessageRepository;
-import io.luna.util.parser.AbstractJsonFileParser;
+import io.luna.files.AbstractJsonFileParser;
 
 import java.lang.reflect.Field;
 

--- a/src/main/java/io/luna/util/parser/impl/NpcCombatDefinitionFileParser.java
+++ b/src/main/java/io/luna/util/parser/impl/NpcCombatDefinitionFileParser.java
@@ -4,7 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.gson.JsonObject;
 import io.luna.game.model.def.NpcCombatDefinition;
 import io.luna.util.GsonUtils;
-import io.luna.util.parser.AbstractJsonFileParser;
+import io.luna.files.AbstractJsonFileParser;
 
 /**
  * A {@link AbstractJsonFileParser} implementation that reads NPC combat definitions.

--- a/src/main/java/io/luna/util/parser/impl/NpcDefinitionFileParser.java
+++ b/src/main/java/io/luna/util/parser/impl/NpcDefinitionFileParser.java
@@ -4,7 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.gson.JsonObject;
 import io.luna.game.model.def.NpcDefinition;
 import io.luna.util.GsonUtils;
-import io.luna.util.parser.AbstractJsonFileParser;
+import io.luna.files.AbstractJsonFileParser;
 
 /**
  * A {@link AbstractJsonFileParser} implementation that reads NPC definitions.

--- a/src/main/java/io/luna/util/parser/impl/ObjectDefinitionFileParser.java
+++ b/src/main/java/io/luna/util/parser/impl/ObjectDefinitionFileParser.java
@@ -4,7 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.gson.JsonObject;
 import io.luna.game.model.def.ObjectDefinition;
 import io.luna.util.GsonUtils;
-import io.luna.util.parser.AbstractJsonFileParser;
+import io.luna.files.AbstractJsonFileParser;
 
 /**
  * A {@link AbstractJsonFileParser} implementation that reads Object definitions.


### PR DESCRIPTION
# Purpose 

Edit: This change is one of many to come that will allow us to maintain a linear dependency tree when migrating the remaining utility classes into their respective packages, as discussed in #180.

# Result
Moves abstract file parsers into a new module called `files`. 

This also introduces the `buildSrc` directory which is automatically detected by gradle.

You can read more about why it exists and how it should be used here: https://docs.gradle.org/current/userguide/organizing_gradle_projects.html#sec:build_sources