### PR TITLE
Get WalkingQueue under test

### DIFF
--- a/src/main/java/io/luna/LunaContext.java
+++ b/src/main/java/io/luna/LunaContext.java
@@ -9,7 +9,7 @@ import io.luna.game.service.GameService;
  *
  * @author lare96 <http://github.org/lare96>
  */
-public final class LunaContext {
+public class LunaContext {
 
     /**
      * The world.

--- a/src/main/java/io/luna/game/model/mob/Player.java
+++ b/src/main/java/io/luna/game/model/mob/Player.java
@@ -643,6 +643,16 @@ public final class Player extends Mob {
         updateRunEnergy();
     }
 
+    boolean hasEnoughEnergyToRun() {
+        return runEnergyAfterReduction() >= 0;
+    }
+
+    /** @return the remaining {@code runEnergy} after a running a single step.*/
+    double runEnergyAfterReduction() {
+        double energyReduction = 0.117 * 2 * Math
+                .pow(Math.E, 0.0027725887222397812376689284858327062723020005374410 * getWeight());
+        return getRunEnergy() - energyReduction;
+    }
     /**
      * @return The combined weight of the inventory and equipment.
      */

--- a/src/main/java/io/luna/game/model/mob/Player.java
+++ b/src/main/java/io/luna/game/model/mob/Player.java
@@ -608,19 +608,23 @@ public final class Player extends Mob {
     /**
      * Sets the run energy percentage.
      *
-     * @param newRunEnergy The value to set to.
+     * @param runEnergy The value to set to.
      */
-    public void setRunEnergy(double newRunEnergy, boolean update) {
-        if (newRunEnergy > 100.0) {
-            newRunEnergy = 100.0;
+    public void setRunEnergy(double runEnergy) {
+        if (runEnergy > 100.0) {
+            runEnergy = 100.0;
         }
 
-        if (runEnergy != newRunEnergy) {
-            runEnergy = newRunEnergy;
-            if (update) {
-                queue(new UpdateRunEnergyMessageWriter((int) runEnergy));
-            }
+        if (runEnergy < 0) {
+            runEnergy = 0;
         }
+
+        this.runEnergy = runEnergy;
+    }
+
+    /** Updates the client with the current run energy. */
+    public void updateRunEnergy() {
+        queue(new UpdateRunEnergyMessageWriter((int) runEnergy));
     }
 
     /**
@@ -635,7 +639,8 @@ public final class Player extends Mob {
         } else if (newEnergy < 0.0) {
             newEnergy = 0.0;
         }
-        setRunEnergy(newEnergy, true);
+        setRunEnergy(newEnergy);
+        updateRunEnergy();
     }
 
     /**

--- a/src/main/java/io/luna/game/model/mob/PlayerSettings.java
+++ b/src/main/java/io/luna/game/model/mob/PlayerSettings.java
@@ -9,7 +9,7 @@ import static java.util.Objects.requireNonNull;
  *
  * @author lare96 <http://github.com/lare96>
  */
-public final class PlayerSettings {
+public class PlayerSettings {
 
     /**
      * An enumerated type whose elements represent brightness levels.

--- a/src/main/java/io/luna/game/model/mob/WalkingQueue.java
+++ b/src/main/java/io/luna/game/model/mob/WalkingQueue.java
@@ -163,7 +163,9 @@ public final class WalkingQueue {
         }
 
         if (restoreEnergy && mob.getType() == EntityType.PLAYER) {
-            incrementRunEnergy();
+            Player player = mob.asPlr();
+            incrementRunEnergy(player);
+            player.updateRunEnergy();
         }
 
         mob.setWalkingDirection(walkingDirection);
@@ -274,20 +276,22 @@ public final class WalkingQueue {
                 .pow(Math.E, 0.0027725887222397812376689284858327062723020005374410 * totalWeight);
         double newValue = player.getRunEnergy() - energyReduction;
         if (newValue <= 0.0) {
-            player.setRunEnergy(0.0, true);
+            player.setRunEnergy(0.0);
+            player.updateRunEnergy();
+
             player.setRunning(false);
             runningPath = false;
             return false;
         }
-        player.setRunEnergy(newValue, true);
+        player.setRunEnergy(newValue);
+        player.updateRunEnergy();
         return true;
     }
 
     /**
      * A function that implements an algorithm to restore run energy.
      */
-    private void incrementRunEnergy() {
-        Player player = mob.asPlr();
+    void incrementRunEnergy(Player player) {
 
         double runEnergy = player.getRunEnergy();
         if (runEnergy >= 100.0) {
@@ -300,7 +304,8 @@ public final class WalkingQueue {
         double newValue = runEnergy + energyRestoration;
         newValue = Math.min(newValue, 100.0);
 
-        player.setRunEnergy(newValue, true);
+        player.setRunEnergy(newValue);
+        player.updateRunEnergy();
     }
 
     /**

--- a/src/main/java/io/luna/game/model/mob/WalkingQueue.java
+++ b/src/main/java/io/luna/game/model/mob/WalkingQueue.java
@@ -94,12 +94,12 @@ public final class WalkingQueue {
     /**
      * A deque of current steps.
      */
-    private final Deque<Step> current = new ArrayDeque<>();
+    private final Deque<Step> currentQueue = new ArrayDeque<>();
 
     /**
      * A deque of previous steps.
      */
-    private final Deque<Step> previous = new ArrayDeque<>();
+    private final Deque<Step> previousQueue = new ArrayDeque<>();
 
     /**
      * The mob.
@@ -131,34 +131,34 @@ public final class WalkingQueue {
      */
     public void process() {
         // TODO clean up function
-        Step current = new Step(mob.getPosition());
+        Step currentStep = new Step(mob.getPosition());
 
         Direction walkingDirection = Direction.NONE;
         Direction runningDirection = Direction.NONE;
 
         boolean restoreEnergy = true;
 
-        Step next = this.current.poll();
-        if (next != null) {
-            previous.add(next);
-            walkingDirection = Direction.between(current, next);
-            current = next;
+        Step nextStep = this.currentQueue.poll();
+        if (nextStep != null) {
+            previousQueue.add(nextStep);
+            walkingDirection = Direction.between(currentStep, nextStep);
+            currentStep = nextStep;
 
             if (mob.getType() == EntityType.PLAYER) {
                 Player player = mob.asPlr();
                 if (player.isRunning() || runningPath) {
-                    next = decrementRunEnergy(player) ? this.current.poll() : null;
-                    if (next != null) {
+                    nextStep = decrementRunEnergy(player) ? this.currentQueue.poll() : null;
+                    if (nextStep != null) {
                         restoreEnergy = false;
-                        previous.add(next);
-                        runningDirection = Direction.between(current, next);
-                        current = next;
+                        previousQueue.add(nextStep);
+                        runningDirection = Direction.between(currentStep, nextStep);
+                        currentStep = nextStep;
                     }
                 }
             }
 
 
-            Position newPosition = new Position(current.getX(), current.getY(), mob.getPosition().getZ());
+            Position newPosition = new Position(currentStep.getX(), currentStep.getY(), mob.getPosition().getZ());
             mob.setPosition(newPosition);
         }
 
@@ -202,23 +202,23 @@ public final class WalkingQueue {
      * @param step The step to add.
      */
     public void addFirst(Step step) {
-        current.clear();
+        currentQueue.clear();
         runningPath = false;
 
         Queue<Step> backtrack = new ArrayDeque<>();
         for (; ; ) {
-            Step prev = previous.pollLast();
+            Step prev = previousQueue.pollLast();
             if (prev == null) {
                 break;
             }
             backtrack.add(prev);
             if (prev.equals(step)) {
                 backtrack.forEach(this::add);
-                previous.clear();
+                previousQueue.clear();
                 return;
             }
         }
-        previous.clear();
+        previousQueue.clear();
 
         add(step);
     }
@@ -229,7 +229,7 @@ public final class WalkingQueue {
      * @param next The step to add.
      */
     public void add(Step next) {
-        Step last = current.peekLast();
+        Step last = currentQueue.peekLast();
         if (last == null) {
             last = new Step(mob.getPosition());
         }
@@ -253,7 +253,7 @@ public final class WalkingQueue {
             } else if (deltaY > 0) {
                 deltaY--;
             }
-            current.add(new Step(nextX - deltaX, nextY - deltaY));
+            currentQueue.add(new Step(nextX - deltaX, nextY - deltaY));
         }
     }
 
@@ -261,8 +261,8 @@ public final class WalkingQueue {
      * Clears the current and previous steps.
      */
     public void clear() {
-        current.clear();
-        previous.clear();
+        currentQueue.clear();
+        previousQueue.clear();
     }
 
     /**
@@ -314,7 +314,7 @@ public final class WalkingQueue {
      * @return The amount of remaining steps.
      */
     public int getRemainingSteps() {
-        return current.size();
+        return currentQueue.size();
     }
 
     /**

--- a/src/main/java/io/luna/game/model/mob/WalkingQueue.java
+++ b/src/main/java/io/luna/game/model/mob/WalkingQueue.java
@@ -115,7 +115,6 @@ public class WalkingQueue {
      * If the current path is a running path.
      */
     private boolean runningPath;
-
     /**
      * Create a new {@link WalkingQueue}.
      *
@@ -149,7 +148,7 @@ public class WalkingQueue {
                 if (player.isRunning() || runningPath) {
                     if (player.hasEnoughEnergyToRun()) {
                         useEnergy(player);
-                        player.updateRunEnergy();
+                        updateEnergy();
                         nextStep = this.currentQueue.poll();
                     } else {
                         nextStep = null;
@@ -170,11 +169,15 @@ public class WalkingQueue {
         if (restoreEnergy && mob.getType() == EntityType.PLAYER) {
             Player player = mob.asPlr();
             incrementRunEnergy(player);
-            player.updateRunEnergy();
+            updateEnergy();
         }
 
         mob.setWalkingDirection(walkingDirection);
         mob.setRunningDirection(runningDirection);
+    }
+
+    void updateEnergy(){
+        mob.asPlr().updateRunEnergy();
     }
 
     /**

--- a/src/main/java/io/luna/game/model/mob/WalkingQueue.java
+++ b/src/main/java/io/luna/game/model/mob/WalkingQueue.java
@@ -17,7 +17,7 @@ import static com.google.common.base.Preconditions.checkState;
  * @author lare96 <http://github.org/lare96>
  * @author Graham
  */
-public final class WalkingQueue {
+public class WalkingQueue {
 
     // TODO Rewrite
 

--- a/src/main/java/io/luna/game/model/mob/WalkingQueue.java
+++ b/src/main/java/io/luna/game/model/mob/WalkingQueue.java
@@ -147,7 +147,11 @@ public final class WalkingQueue {
             if (mob.getType() == EntityType.PLAYER) {
                 Player player = mob.asPlr();
                 if (player.isRunning() || runningPath) {
-                    nextStep = decrementRunEnergy(player) ? this.currentQueue.poll() : null;
+                    if (decrementRunEnergy(player)) {
+                        nextStep = this.currentQueue.poll();
+                    } else {
+                        nextStep = null;
+                    }
                     if (nextStep != null) {
                         restoreEnergy = false;
                         previousQueue.add(nextStep);
@@ -156,7 +160,6 @@ public final class WalkingQueue {
                     }
                 }
             }
-
 
             Position newPosition = new Position(currentStep.getX(), currentStep.getY(), mob.getPosition().getZ());
             mob.setPosition(newPosition);
@@ -204,7 +207,6 @@ public final class WalkingQueue {
     public void addFirst(Step step) {
         currentQueue.clear();
         runningPath = false;
-
         Queue<Step> backtrack = new ArrayDeque<>();
         for (; ; ) {
             Step prev = previousQueue.pollLast();
@@ -305,7 +307,6 @@ public final class WalkingQueue {
         newValue = Math.min(newValue, 100.0);
 
         player.setRunEnergy(newValue);
-        player.updateRunEnergy();
     }
 
     /**

--- a/src/main/java/io/luna/game/model/mob/WalkingQueue.java
+++ b/src/main/java/io/luna/game/model/mob/WalkingQueue.java
@@ -147,7 +147,7 @@ public final class WalkingQueue {
             if (mob.getType() == EntityType.PLAYER) {
                 Player player = mob.asPlr();
                 if (player.isRunning() || runningPath) {
-                    if (hasEnoughEnergyToRun(player)) {
+                    if (player.hasEnoughEnergyToRun()) {
                         useEnergy(player);
                         player.updateRunEnergy();
                         nextStep = this.currentQueue.poll();
@@ -177,23 +177,12 @@ public final class WalkingQueue {
         mob.setRunningDirection(runningDirection);
     }
 
-    double getRemainingEnergy(double weight, double runEnergy) {
-        double energyReduction = 0.117 * 2 * Math
-                .pow(Math.E, 0.0027725887222397812376689284858327062723020005374410 * weight);
-        return runEnergy - energyReduction;
-    }
-
-    boolean hasEnoughEnergyToRun(Player player) {
-        double energyRemaining = getRemainingEnergy(player.getWeight(), player.getRunEnergy());
-        return energyRemaining >= 0;
-    }
-
     /**
      * Depletes a player's energy. If the player doesn't have enough energy, the player will stop running.
      */
     void useEnergy(Player player) {
-        double energyLeft = getRemainingEnergy(player.getWeight(), player.getRunEnergy());
-        if (hasEnoughEnergyToRun(player)) {
+        double energyLeft = player.runEnergyAfterReduction();
+        if (player.hasEnoughEnergyToRun()) {
             player.setRunEnergy(energyLeft);
         } else {
             player.setRunEnergy(0.0);

--- a/src/main/java/io/luna/game/model/mob/persistence/PlayerData.java
+++ b/src/main/java/io/luna/game/model/mob/persistence/PlayerData.java
@@ -66,7 +66,7 @@ public final class PlayerData {
         player.getIgnores().addAll(ignores);
         player.setUnbanDate(unbanDate);
         player.setUnmuteDate(unmuteDate);
-        player.setRunEnergy(runEnergy, false);
+        player.setRunEnergy(runEnergy);
         player.setWeight(weight, false);
         player.getAttributes().load(attributes);
     }

--- a/src/test/java/io/luna/game/model/mob/NullPlayerSettings.java
+++ b/src/test/java/io/luna/game/model/mob/NullPlayerSettings.java
@@ -1,0 +1,50 @@
+package io.luna.game.model.mob;
+
+/** A {@link PlayerSettings} designed for testing purposes only. */
+public class NullPlayerSettings extends PlayerSettings {
+
+    @Override
+    public void showRunning() {
+        return;
+    }
+
+    @Override
+    public void showAutoRetaliate() {
+        return;
+    }
+
+    @Override
+    public void showBrightnessLevel() {
+        return;
+    }
+
+    @Override
+    public void showMouseType() {
+        return;
+    }
+
+    @Override
+    public void showChatEffects() {
+        return;
+    }
+
+    @Override
+    public void showSplitPrivateChat() {
+        return;
+    }
+
+    @Override
+    public void showAcceptAid() {
+        return;
+    }
+
+    @Override
+    public void showMusicVolume() {
+        return;
+    }
+
+    @Override
+    public void showEffectsVolume() {
+        return;
+    }
+}

--- a/src/test/java/io/luna/game/model/mob/NullWalkingQueue.java
+++ b/src/test/java/io/luna/game/model/mob/NullWalkingQueue.java
@@ -1,0 +1,20 @@
+package io.luna.game.model.mob;
+
+/**
+ * A {@link WalkingQueue} designed for testing purposes only.
+ */
+class NullWalkingQueue extends WalkingQueue {
+    /**
+     * Create a new {@link WalkingQueue}.
+     *
+     * @param mob The mob.
+     */
+    NullWalkingQueue(Mob mob) {
+        super(mob);
+    }
+
+    @Override
+    void updateEnergy() {
+        return;
+    }
+}

--- a/src/test/java/io/luna/game/model/mob/WalkingQueueTest.java
+++ b/src/test/java/io/luna/game/model/mob/WalkingQueueTest.java
@@ -1,0 +1,111 @@
+package io.luna.game.model.mob;
+
+import io.luna.LunaContext;
+import io.luna.game.model.Position;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+class WalkingQueueTest {
+    private final PlayerCredentials credentials = new PlayerCredentials("test", "test");
+    private final LunaContext context = mock(LunaContext.class);
+    private final Player player = new Player(context, credentials);
+
+    private final WalkingQueue queue = new NullWalkingQueue(player);
+    private final Position startPosition = new Position(0, 0);
+
+
+    private WalkingQueueTest() {
+        player.setSettings(new NullPlayerSettings());
+    }
+
+    @BeforeEach
+    void init() {
+        player.setPosition(startPosition);
+        player.setRunning(false);
+        queue.clear();
+    }
+
+    @Test
+    void whenPlayerIsNotMoving_thenDoNotTakeAnySteps() {
+        player.setPosition(startPosition);
+
+        //No movement applied
+        queue.process();
+
+        assertEquals(startPosition, player.getPosition());
+    }
+
+    @Test
+    void whenPlayerIsWalking_thenTakeOneStep() {
+        player.setRunEnergy(100);
+
+        queue.walk(2, 2);
+        queue.process();
+
+        var stepsTaken = player.getPosition().computeLongestDistance(startPosition);
+        assertEquals(stepsTaken, 1);
+    }
+
+    @Test
+    void whenPlayerIsNotMoving_thenIncreaseRunEnergy() {
+        var startingEnergy = 0.0;
+        player.setRunEnergy(startingEnergy);
+        player.setPosition(startPosition);
+
+        // No movement applied
+        queue.process();
+
+        assertTrue(player.getRunEnergy() > startingEnergy);
+    }
+
+    @Test
+    void whenPlayerIsWalking_thenIncreaseRunEnergy() {
+        var startingEnergy = 0.0;
+        player.setRunEnergy(startingEnergy);
+        player.setPosition(startPosition);
+
+        queue.walk(1, 1);
+        queue.process();
+
+        assertTrue(player.getRunEnergy() > startingEnergy);
+    }
+    @Test
+    void whenPlayerIsRunning_AndHasEnergy_thenDecreaseRunEnergy(){
+        var startingEnergy = 100;
+        player.setRunEnergy(startingEnergy);
+        player.setRunning(true);
+
+        queue.walk(2, 2);
+        queue.process();
+
+        assertTrue(player.getRunEnergy() < startingEnergy);
+    }
+
+    @Test
+    void whenPlayerIsRunning_AndHasEnergy_thenTakeTwoSteps() {
+        player.setRunEnergy(100);
+        player.setRunning(true);
+
+        queue.walk(2, 2);
+        queue.process();
+
+        var stepsTaken = player.getPosition().computeLongestDistance(startPosition);
+        assertEquals(stepsTaken, 2);
+    }
+
+    @Test
+    void whenPlayerIsRunning_AndOutOfEnergy_thenTakeOneStep() {
+        player.setRunEnergy(0);
+        player.setRunning(true);
+
+        queue.walk(2, 2);
+        queue.process();
+
+        var stepsTaken = player.getPosition().computeLongestDistance(startPosition);
+        assertEquals(stepsTaken, 1);
+    }
+}


### PR DESCRIPTION
Thank you for contributing to the Luna project! 

## Proposed changes

The goal here is to create tests for WalkingQueue. This will allow me to refactor the class without losing any of the object's behaviours. 

Once WalkingQueue is under test, I'll be able to address #186

## Pull Request type

What types of changes does your code introduce to Luna?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/luna-rs/luna/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally, after applying my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added necessary documentation
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

The removal of the 'final' keyword from LunaContext, WalkingQueue, and PlayerSettings were to mock/create null objects. By doing so, WalkingQueue can be tested without any existing network connections and/or configuration files.