### PR TITLE
fix fourth click on items

### DIFF
--- a/src/main/java/io/luna/net/msg/in/ItemClickMessageReader.java
+++ b/src/main/java/io/luna/net/msg/in/ItemClickMessageReader.java
@@ -46,9 +46,9 @@ public final class ItemClickMessageReader extends GameMessageReader<ItemClickEve
                 interfaceId = payload.getShort(true, ByteOrder.LITTLE, ValueType.ADD);
                 return new ItemThirdClickEvent(player, id, index, interfaceId);
             case 228:
-                interfaceId = payload.getShort(true, ByteOrder.LITTLE, ValueType.ADD);
-                index = payload.getShort(true, ByteOrder.LITTLE, ValueType.ADD);
+                index = payload.getShort(true, ByteOrder.LITTLE, ValueType.NORMAL);
                 id = payload.getShort(false, ValueType.ADD);
+                interfaceId = payload.getShort(true);
                 return new ItemFourthClickEvent(player, id, index, interfaceId);
             case 4:
                 id = payload.getShort(false, ValueType.ADD);

--- a/src/main/kotlin/api/shop/dsl/OpenReceiver.kt
+++ b/src/main/kotlin/api/shop/dsl/OpenReceiver.kt
@@ -15,7 +15,7 @@ class OpenReceiver {
     // These properties are mapped to functions in EventPredef.kt with the same name.
     var button: Int? = null
     var npc1: Int? = null
-    var npc2: Int? = null
+    var npc2: IntArray? = null
     var npc3: Int? = null
     var npc4: Int? = null
     var npc5: Int? = null
@@ -31,7 +31,7 @@ class OpenReceiver {
         when {
             button != null -> button(button!!, open)
             npc1 != null -> npc1(npc1!!, open)
-            npc2 != null -> npc2(npc2!!, open)
+            npc2 != null -> npc2!!.forEach { npc2(it, open) }
             npc3 != null -> npc3(npc3!!, open)
             npc4 != null -> npc4(npc4!!, open)
             npc5 != null -> npc5(npc5!!, open)

--- a/src/main/kotlin/world/location/lumbridge/info.plugin.kts
+++ b/src/main/kotlin/world/location/lumbridge/info.plugin.kts
@@ -1,0 +1,13 @@
+package world.location.lumbridge
+
+import api.plugin.dsl.plugin
+
+plugin {
+    name = "Lumbridge"
+    description =
+        """
+        A plugin that poplates Lumbridge with NPCs.
+        """
+    version = "1.0"
+    authors += "hydrozoa"
+}

--- a/src/main/kotlin/world/location/lumbridge/lumbridge.kts
+++ b/src/main/kotlin/world/location/lumbridge/lumbridge.kts
@@ -1,0 +1,85 @@
+package world.location.lumbridge
+
+import api.predef.*
+import api.predef.ext.*
+import api.shop.dsl.ShopHandler
+import io.luna.game.event.impl.ServerStateChangedEvent.ServerLaunchEvent
+import io.luna.game.model.item.shop.BuyPolicy
+import io.luna.game.model.item.shop.Currency
+import io.luna.game.model.item.shop.RestockPolicy
+import io.luna.game.model.mob.dialogue.Expression
+
+npc1(520) {
+    plr.newDialogue()
+        .npc(targetNpc.id, "Hi, here's what I have in stock for today!")
+        .then { it.interfaces.openShop("General Store") }.open()
+}
+
+npc1(521) {
+    plr.newDialogue()
+        .npc(targetNpc.id, "I'm the assistant!")
+        .then { it.interfaces.openShop("General Store") }.open()
+}
+
+// Hans dialogue
+npc1(0) {
+    plr.newDialogue()
+        .npc(targetNpc.id, "Hello. What are you doing here?")
+        .options(
+            "I'm looking for whoever is in charge of this place.", {
+                plr.newDialogue()
+                    .player("I'm looking for whoever is in charge of this place.")
+                    .npc(targetNpc.id, "Who, the Duke? He's in his study, on the first floor.").open()
+            },
+            "I have come to kill everyone in this castle!", {
+                plr.newDialogue()
+                    .player(Expression.ANGRY, "I have come to kill everyone in this castle!")
+                    .then { targetNpc.forceChat("Help! Help!") }
+                    .open()
+            },
+            "Can you tell me how long I've been here?", {
+                plr.newDialogue()
+                    .player("Can you tell me how long I've been here?")
+                    .npc(
+                        targetNpc.id,
+                        Expression.LAUGHING,
+                        "Ahh, I see all the newcomers arriving in Lumbridge,",
+                        "fresh-faced and eager for adventure. I remember you..."
+                    )
+                    .npc(
+                        targetNpc.id,
+                        "You've spent x days, y hours, z minutes in the",
+                        "world since you arrived t days ago."
+                    )
+                    .open()
+            })
+        .open()
+}
+
+on(ServerLaunchEvent::class) {
+    // General store npcs
+    world.addNpc(
+        id = 520,
+        x = 3212,
+        y = 3245)
+    world.addNpc(
+        id = 521,
+        x = 3212,
+        y = 3248)
+
+    // Hans
+    world.addNpc(
+        id = 0,
+        x = 3221,
+        y = 3224)
+
+    // Men
+    world.addNpc(
+        id = 1,
+        x = 3222,
+        y = 3215)
+    world.addNpc(
+        id = 2,
+        x = 3235,
+        y = 3219)
+}

--- a/src/main/kotlin/world/npc/shop/generalStore/generalStore.kts
+++ b/src/main/kotlin/world/npc/shop/generalStore/generalStore.kts
@@ -29,7 +29,7 @@ ShopHandler.create("General Store") {
     }
 
     open {
-        npc2 = 520
+        npc2 = intArrayOf(520, 521)
     }
 }
 
@@ -43,10 +43,23 @@ npc1(520) {
 }
 
 /**
+ * Dialogue for "Talk" option.
+ */
+npc1(521) {
+    plr.newDialogue()
+        .npc(targetNpc.id, "I'm the assistant!")
+        .then { it.interfaces.openShop("General Store") }.open()
+}
+
+/**
  * Spawn general store NPC.
  */
 on(ServerLaunchEvent::class) {
     world.addNpc(id = 520,
                  x = 3091,
                  y = 3250)
+    world.addNpc(
+        id = 521,
+        x = 3090,
+        y = 3250)
 }


### PR DESCRIPTION
## Proposed changes

When an item is clicked it generates a packet that is read in ItemClickMessageReader.java. This fixes a bug where the fourth option on items weren't being correctly read.

I tested the code using tuna and games necklace, verifying that the index and interfaceId matched. 

## Pull Request type

What types of changes does your code introduce to Luna?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/luna-rs/luna/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally, after applying my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation
- [ ] Any dependent changes have been merged and published in downstream modules