### PR TITLE
Fix for fourth option click on items in inventory

### DIFF
--- a/src/main/java/io/luna/net/msg/in/ItemClickMessageReader.java
+++ b/src/main/java/io/luna/net/msg/in/ItemClickMessageReader.java
@@ -46,9 +46,9 @@ public final class ItemClickMessageReader extends GameMessageReader<ItemClickEve
                 interfaceId = payload.getShort(true, ByteOrder.LITTLE, ValueType.ADD);
                 return new ItemThirdClickEvent(player, id, index, interfaceId);
             case 228:
-                interfaceId = payload.getShort(true, ByteOrder.LITTLE, ValueType.ADD);
-                index = payload.getShort(true, ByteOrder.LITTLE, ValueType.ADD);
+                index = payload.getShort(true, ByteOrder.LITTLE, ValueType.NORMAL);
                 id = payload.getShort(false, ValueType.ADD);
+                interfaceId = payload.getShort(true);
                 return new ItemFourthClickEvent(player, id, index, interfaceId);
             case 4:
                 id = payload.getShort(false, ValueType.ADD);


### PR DESCRIPTION
## Proposed changes

When an item in the inventory is clicked it generates a packet. Depending on the option clicked, it should be processed differently. 
This fixes the processing of the fourth option, used when rubbing a games necklace.

## Pull Request type

What types of changes does your code introduce to Luna?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/luna-rs/luna/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally, after applying my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation
- [ ] Any dependent changes have been merged and published in downstream modules