### PR TITLE
Fix standard spellbook teleport graphic

### DIFF
--- a/src/main/kotlin/world/player/skill/magic/Magic.kt
+++ b/src/main/kotlin/world/player/skill/magic/Magic.kt
@@ -119,24 +119,18 @@ object Magic {
                 sound.display()
                 true
             }
-
             1 -> {
                 plr.animation(Animation(714))
+                plr.graphic(Graphic(111, 92))
                 true
             }
-
-            2 -> {
-                plr.graphic(Graphic(308, 50))
-                true
-            }
-
+            2 -> true
             3 -> true
             4 -> {
                 plr.move(action.destination)
                 plr.animation(Animation(715))
                 false
             }
-
             else -> false
         }
     }


### PR DESCRIPTION
## Proposed changes

Standard spellbook teleportation uses the wrong spotamin and timing. This fixes it.

## Pull Request type

What types of changes does your code introduce to Luna?
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/luna-rs/luna/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally, after applying my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

This is a tiny change. I have added a webm showing before and after.

Before:
[Teleport-Before.webm](https://github.com/user-attachments/assets/8d516eee-da0a-452c-bbdf-3aca1ffccd98)

After:
[Teleport-After.webm](https://github.com/user-attachments/assets/7331dd60-c741-4b33-92e4-a5b4dcf33ac1)
