### PR TITLE
feat: Teleport using ring of dueling, amulet of glory or games necklace

### DIFF
--- a/src/main/kotlin/world/player/item/teleJewellery/TeleportJewellery.kt
+++ b/src/main/kotlin/world/player/item/teleJewellery/TeleportJewellery.kt
@@ -1,0 +1,49 @@
+package world.player.item.teleJewellery
+
+import io.luna.game.model.*
+
+/**
+ * An enum representing jewellery that can be used to teleport.
+ */
+enum class TeleportJewellery(val itemIDs: IntArray,
+    val destinations: Array<Destination>,
+    val rubMessage : String,
+    val crumbleMessage : String,
+    val disappear: Boolean) {
+
+    GAMES_NECKLACE(
+        intArrayOf(3853, 3855, 3857, 3859, 3861, 3863, 3865, 3867),
+        arrayOf(
+            Destination(Position(2898, 3546), "Burthorpe."),
+            Destination(Position(2536, 3565), "Barbarian Outpost.")
+        ),
+        "You rub the necklace...",
+        "Your Games necklace crumbles to dust.",
+        true
+    ),
+    DUELING_RING(
+        intArrayOf(2552, 2554, 2556, 2558, 2560, 2562, 2564, 2566),
+        arrayOf(
+            Destination(Position(3316, 3235), "Al Kharid Duel Arena."),
+            Destination(Position(2441, 3089), "Castle Wars Arena.")
+        ),
+        "You rub the ring...",
+        "Your Ring of Dueling crumbles to dust.",
+        true
+    ),
+    AMULET_OF_GLORY(
+        intArrayOf(1712, 1710, 1708, 1706, 1704),
+        arrayOf(
+            Destination(Position(3087, 3504), "Edgeville."),
+            Destination(Position(2912, 3169), "Karamja."),
+            Destination(Position(3105, 3264), "Draynor Village."),
+            Destination(Position(3290, 3181), "Al Kharid.")
+        ),
+        "You rub the amulet...",
+        "Your Amulet of Glory needs to be recharged.",
+        false
+    ),
+    ;
+}
+
+data class Destination(val destination: Position, val destinationName: String)

--- a/src/main/kotlin/world/player/item/teleJewellery/info.plugin.kts
+++ b/src/main/kotlin/world/player/item/teleJewellery/info.plugin.kts
@@ -1,0 +1,14 @@
+package world.player.item.teleJewellery
+
+import api.plugin.dsl.plugin
+
+plugin {
+    name = "Teleport Jewellery"
+    description =
+        """
+        A plugin that enables players to use games necklace, dueling ring and amulet of glory.
+        """
+    version = "1.0"
+    corePlugin = false
+    authors += "hydrozoa"
+}

--- a/src/main/kotlin/world/player/item/teleJewellery/teleJewellery.kts
+++ b/src/main/kotlin/world/player/item/teleJewellery/teleJewellery.kts
@@ -1,0 +1,83 @@
+package world.player.item.teleJewellery
+
+import api.predef.*
+import api.predef.ext.*
+import io.luna.game.model.mob.Player
+import io.luna.game.model.Position
+import io.luna.game.model.item.*
+import io.luna.game.model.mob.dialogue.DialogueQueueBuilder.DialogueOption
+import io.luna.util.StringUtils
+import world.player.skill.magic.teleportSpells.TeleportAction.Companion.teleportDelay
+import world.player.skill.magic.teleportSpells.TeleportStyle
+import world.player.skill.magic.teleportSpells.TeleportAction
+import world.player.skill.magic.SpellRequirement
+
+TeleportJewellery.values().forEach {
+    val jewellery = it
+
+    for (i in 0..jewellery.itemIDs.size-1) {
+        val itemID: Int = jewellery.itemIDs.get(i)
+        val lastItem: Boolean = i == jewellery.itemIDs.size-1
+
+        if (lastItem && !jewellery.disappear) {
+            item4(itemID) {
+                plr.sendMessage(jewellery.crumbleMessage)
+            }
+            continue
+        }
+
+        item4(itemID) {
+            plr.sendMessage(jewellery.rubMessage)
+            world.scheduleOnce(1, {
+                val dialogueOptions = mutableListOf<DialogueOption>()
+                for (destination in jewellery.destinations) {
+                    dialogueOptions.add(DialogueOption(destination.destinationName, {
+                        teleport(plr, destination.destination, destination.destinationName)
+                        degrade(plr, itemID, index, jewellery)
+                    }))
+                }
+                dialogueOptions.add(DialogueOption("Nowhere.", {
+                    plr.resetDialogues()
+                }))
+
+                plr.newDialogue()
+                    .options(dialogueOptions)
+                    .open()
+            })
+        }
+    }
+}
+
+fun degrade(plr: Player, necklaceId: Int, index: Int, type: TeleportJewellery) {
+    plr.inventory.remove(index, Item(necklaceId, 1))
+
+    val jewelleryIndex = type.itemIDs.indexOf(necklaceId)
+    val lastCharge = (!type.disappear && jewelleryIndex+2 == type.itemIDs.size)
+            || (type.disappear && jewelleryIndex+1 == type.itemIDs.size)
+
+    if (lastCharge) {
+        plr.sendMessage(type.crumbleMessage)
+        if (type.disappear) {
+            return
+        }
+    }
+    val nextJewellery = type.itemIDs.get(jewelleryIndex+1)
+    plr.inventory.add(index, Item(nextJewellery, 1))
+}
+
+fun teleport(plr: Player, pos: Position, destinationName: String) {
+    if (plr.teleportDelay.ready(2)) { // So player can't button spam.
+        plr.submitAction(object : TeleportAction(
+            plr,
+            0,
+            0.0,
+            pos,
+            TeleportStyle.REGULAR,
+            emptyList<SpellRequirement>()
+        ) {
+            override fun onTeleport() {
+                plr.sendMessage("You teleport to ${StringUtils.capitalize(destinationName)}")
+            }
+        })
+    }
+}


### PR DESCRIPTION
## Proposed changes

This adds a plugin that handles teleporting with jewellery. It supports games necklace, ring of dueling and amulet of glory. 

## Pull Request type

What types of changes does your code introduce to Luna?
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/luna-rs/luna/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally, after applying my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

None.