### PR TITLE
Fix fishing message showing id instead of name

### DIFF
--- a/src/main/kotlin/world/player/skill/fishing/catchFish/CatchFishAction.kt
+++ b/src/main/kotlin/world/player/skill/fishing/catchFish/CatchFishAction.kt
@@ -3,6 +3,7 @@ package world.player.skill.fishing.catchFish
 import api.predef.*
 import io.luna.game.action.impl.ItemContainerAction.InventoryAction
 import io.luna.game.event.impl.NpcClickEvent
+import io.luna.game.model.def.*
 import io.luna.game.model.item.Item
 import io.luna.game.model.mob.block.Animation
 import world.player.Sounds
@@ -55,7 +56,8 @@ class CatchFishAction(private val msg: NpcClickEvent,
 
             !mob.inventory.contains(tool.id) -> {
                 // Check if we have required tool.
-                mob.sendMessage("You need ${addArticle(tool.id)} to fish here.")
+                val toolName = ItemDefinition.ALL.retrieve(tool.id).name
+                mob.sendMessage("You need ${addArticle(toolName)} to fish here.")
                 false
             }
 


### PR DESCRIPTION
## Proposed changes

When fishing without the required tool, the message reads "You need a 303 to fish here". This changes that to the name of item 303 instead.

## Pull Request type

What types of changes does your code introduce to Luna?
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/luna-rs/luna/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally, after applying my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation
- [x] Any dependent changes have been merged and published in downstream modules

## Additional comments
The following video shows the bug.
[fishing-message.webm](https://github.com/user-attachments/assets/a3362853-463d-4842-a876-5e3fa3f0f398)