### PR TITLE
Fix: Walk east after lighting fire

### DIFF
--- a/src/main/kotlin/world/player/skill/firemaking/LightLogAction.kt
+++ b/src/main/kotlin/world/player/skill/firemaking/LightLogAction.kt
@@ -63,11 +63,12 @@ class LightLogAction(plr: Player, val log: Log, val removeLog: Boolean) :
 
             // Walk in a non-blocked direction prioritizing east
             val collision = mob.world.collisionManager
-            val directions = listOf(Direction.EAST, Direction.WEST, Direction.SOUTH, Direction.NORTH)
+            val directions = listOf(Direction.WEST, Direction.EAST, Direction.SOUTH, Direction.NORTH)
             for (dir in directions) {
                 if (collision.traversable(mob.position, EntityType.NPC, dir)) {
-                    mob.walking.walk(mob.position.translate(1, dir))
-                    world.scheduleOnce(1, {
+                    val newPosition = mob.position.translate(1, dir)
+                    mob.walking.walk(newPosition)
+                    world.scheduleOnce(2, {
                         mob.face(dir.opposite())
                     })
                     break

--- a/src/main/kotlin/world/player/skill/firemaking/LightLogAction.kt
+++ b/src/main/kotlin/world/player/skill/firemaking/LightLogAction.kt
@@ -13,6 +13,11 @@ import world.player.*
 class LightLogAction(plr: Player, val log: Log, val removeLog: Boolean) :
     LightAction(plr, Firemaking.computeLightDelay(plr, log)) {
 
+    /**
+     * Directions in prioritized order to try to walk after lighting a log
+     */
+    private val WALK_DIRECTIONS : List<Direction> = listOf(Direction.WEST, Direction.EAST, Direction.SOUTH, Direction.NORTH)
+
     override fun canLight(): Boolean {
 
         return when {
@@ -63,14 +68,15 @@ class LightLogAction(plr: Player, val log: Log, val removeLog: Boolean) :
 
             // Walk in a non-blocked direction prioritizing east
             val collision = mob.world.collisionManager
-            val directions = listOf(Direction.WEST, Direction.EAST, Direction.SOUTH, Direction.NORTH)
-            for (dir in directions) {
+            for (dir in WALK_DIRECTIONS) {
                 if (collision.traversable(mob.position, EntityType.NPC, dir)) {
                     val newPosition = mob.position.translate(1, dir)
                     mob.walking.walk(newPosition)
-                    world.scheduleOnce(2, {
+                    mob.lock()
+                    world.scheduleOnce(2) {
                         mob.face(dir.opposite())
-                    })
+                        mob.unlock()
+                    }
                     break
                 }
             }

--- a/src/main/kotlin/world/player/skill/firemaking/LightLogAction.kt
+++ b/src/main/kotlin/world/player/skill/firemaking/LightLogAction.kt
@@ -66,13 +66,13 @@ class LightLogAction(plr: Player, val log: Log, val removeLog: Boolean) :
             }
             mob.firemaking.addExperience(log.exp)
 
-            // Walk in a non-blocked direction prioritizing east
+            // Walk in a non-blocked direction prioritizing west
             val collision = mob.world.collisionManager
             for (dir in WALK_DIRECTIONS) {
                 if (collision.traversable(mob.position, EntityType.NPC, dir)) {
                     val newPosition = mob.position.translate(1, dir)
-                    mob.walking.walk(newPosition)
                     mob.lock()
+                    mob.walking.walk(newPosition)
                     world.scheduleOnce(2) {
                         mob.face(dir.opposite())
                         mob.unlock()

--- a/src/main/kotlin/world/player/skill/firemaking/LightLogAction.kt
+++ b/src/main/kotlin/world/player/skill/firemaking/LightLogAction.kt
@@ -75,6 +75,8 @@ class LightLogAction(plr: Player, val log: Log, val removeLog: Boolean) :
                     mob.walking.walk(newPosition)
                     world.scheduleOnce(2) {
                         mob.face(dir.opposite())
+                    }
+                    world.scheduleOnce(3) {
                         mob.unlock()
                     }
                     break


### PR DESCRIPTION
## Proposed changes

Currently when firemaking after lighting a log the player steps in a random direction. This is not the correct behavior, and frankly a hindrance to training firemaking, due to it being unpredictable. 
This fix makes the player step east, and then facing back towards the fire after walking. If east is blocked the other directions are considered.

## Pull Request type

What types of changes does your code introduce to Luna?
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/luna-rs/luna/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally, after applying my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added necessary documentation
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Here's a video showing the behavior of this PR.

[Walk-East-Firemaking.webm](https://github.com/user-attachments/assets/11e2615e-97f2-4172-86f9-48205ce45be3)