### PR TITLE
Fix database connection error when using JsonGameSerializer

### DIFF
--- a/src/main/java/io/luna/game/model/World.java
+++ b/src/main/java/io/luna/game/model/World.java
@@ -16,8 +16,7 @@ import io.luna.game.model.mob.Player;
 import io.luna.game.model.mob.bot.BotManager;
 import io.luna.game.model.mob.bot.BotRepository;
 import io.luna.game.model.object.GameObjectList;
-import io.luna.game.persistence.GameSerializerManager;
-import io.luna.game.persistence.PersistenceService;
+import io.luna.game.persistence.*;
 import io.luna.game.task.Task;
 import io.luna.game.task.TaskManager;
 import io.luna.net.msg.out.NpcUpdateMessageWriter;
@@ -270,14 +269,18 @@ public final class World {
         botManager = new BotManager();
 
         // Initialize the connection pool.
-        try {
-            connectionPool = new SqlConnectionPool.Builder()
-                    .poolName("LunaSqlPool")
-                    .database("luna_players")
-                    .build();
-        } catch (Exception e) {
-            logger.fatal("Fatal error creating SQL pool!", e);
-            throw new RuntimeException(e);
+        if (getSerializerManager().getSerializer() instanceof SqlGameSerializer) {
+            try {
+                connectionPool = new SqlConnectionPool.Builder()
+                        .poolName("LunaSqlPool")
+                        .database("luna_players")
+                        .build();
+            } catch (Exception e) {
+                logger.fatal("Fatal error creating SQL pool!", e);
+                throw new RuntimeException(e);
+            }
+        } else {
+            connectionPool = null;
         }
 
         // Initialize synchronization thread pool.


### PR DESCRIPTION
## Proposed changes

This small change fixes an error caused by trying to connect to the database in the World constructor, regardless of which serializer is configured. When using the json serializer, no database will be available, but the connection pool will be initialized anyway, causing the error. This patch checks if the json serializer is used, and initializes the connection pool to null if it is. This has no side effects, as the only class that uses this connection pool (besides the sql serializer) is BotRepository, and it correctly chooses between local storage and the database, depending on the serializer used.

## Pull Request type
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/luna-rs/luna/blob/master/CONTRIBUTING.md) doc
- [ ] Unit tests pass locally, after applying my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
None.