### PR TITLE
Bugfix: Clear dialogues when walking away

### DIFF
--- a/src/main/kotlin/engine/engine/player/walking.kts
+++ b/src/main/kotlin/engine/engine/player/walking.kts
@@ -13,6 +13,7 @@ on(WalkingEvent::class, EventPriority.HIGH) {
         plr.resetInteractingWith()
         plr.resetInteractionTask()
     }
+    plr.overlays.closeWindows()
     plr.walking.clear()
     plr.walking.addPath(steps)
 }


### PR DESCRIPTION
## Proposed changes

Currently the closeAction on dialogues run even when the dialogue is exited by walking away. This is a problem for shopkeepers. The attached video displays behavior for the following code:
```
plr.newDialogue()
        .npc(targetNpc.id, "I'm the assistant!")
        .then { it.overlays.open(ShopInterface(world, "General Store")) }.open()
```

https://github.com/user-attachments/assets/80cd11eb-1ed5-44b5-afb6-b03a59b73198

The correct behavior would be that the shop only opens when continue is clicked. The following video displays the behavior after the proposed change.

https://github.com/user-attachments/assets/f5b0e460-e380-43e4-9833-9b88076db9af

## Pull Request type
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/luna-rs/luna/blob/master/CONTRIBUTING.md) doc
- [ ] Unit tests pass locally, after applying my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

None.