### PR TITLE
Bugfix: Delay hits one tick

### DIFF
--- a/src/main/java/io/luna/game/model/mob/combat/CombatAction.java
+++ b/src/main/java/io/luna/game/model/mob/combat/CombatAction.java
@@ -9,6 +9,7 @@ import io.luna.game.model.collision.CollisionManager;
 import io.luna.game.model.mob.Mob;
 import io.luna.game.model.mob.Npc;
 import io.luna.game.model.mob.interact.InteractionPolicy;
+import io.luna.game.task.Task;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -139,7 +140,13 @@ public final class CombatAction extends Action<Mob> {
 
         mob.animation(combat.getAttackAnimation());
 
-        damage.apply();
+        world.schedule(new Task(false, 1) {
+            @Override
+            protected void execute() {
+                damage.apply();
+                cancel();
+            }
+        });
         victim.animation(combat.getDefenceAnimation());
         victim.getCombat().resetCombatTimer();
         retaliate();


### PR DESCRIPTION
(cherry picked from commit 4349c07624494f61d416419a7c96f1ee12571a36)

## Proposed changes

Currently hitsplats are sent the same tick as the attack animation. They should be delayed, so the attack animation plays and then one tick later the hitsplat appears.

This proposal registers the damage as a single-run Task that runs one tick later.

## Pull Request type

What types of changes does your code introduce to Luna?
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/luna-rs/luna/blob/master/CONTRIBUTING.md) doc
- [ ] Unit tests pass locally, after applying my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

None.