### PR TITLE
Bugfix: Reduce dancing during combat

### DIFF
--- a/src/main/java/io/luna/game/model/mob/combat/CombatAction.java
+++ b/src/main/java/io/luna/game/model/mob/combat/CombatAction.java
@@ -104,11 +104,8 @@ public final class CombatAction extends Action<Mob> {
                 mob.getNavigator().walkTo(target, Optional.empty(), false);
             }
             return false;
-        } else {
-            if (!mob.getWalking().isEmpty()) {
-                mob.getWalking().clear();
-            }
-        }
+        }        
+        mob.getWalking().clear();
 
         // TODO Players shouldn't be allowed to attack at all if on the same position? Unless it's magic/ranged?
         if (position.equals(target.getPosition()) && mob instanceof Npc) {
@@ -120,7 +117,6 @@ public final class CombatAction extends Action<Mob> {
             }
         }
         if (combat.isAttackReady() && Objects.equals(mob.getInteractingWith(), combat.getTarget())) {
-            mob.getWalking().clear();
             combat.resetAttackDelay();
             combat.resetCombatTimer();
             launchMeleeAttack();


### PR DESCRIPTION
(cherry picked from commit 185da98adc27441e558f052a10bebd448c2a964e)

## Proposed changes

During combat, sometimes the walking queue is not empty even though the target has been reached. This causing some extra pathing. This proposal fixes this by clearing the walking queue when the target is reached.

## Pull Request type
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/luna-rs/luna/blob/master/CONTRIBUTING.md) doc
- [ ] Unit tests pass locally, after applying my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

There still is some wonky pathing where NPCs will walk one tile further than strictly necessary. I think this is due to a bug in WalkingNavigator#walkTo.