### PR TITLE
Bugfix: WanderingAction never runs

### DIFF
--- a/src/main/java/io/luna/game/model/mob/wandering/WanderingAction.java
+++ b/src/main/java/io/luna/game/model/mob/wandering/WanderingAction.java
@@ -37,7 +37,7 @@ public abstract class WanderingAction extends Action<Mob> {
     @Override
     public final boolean run() {
         if (!mob.getCombat().inCombat() && mob.getWalking().isEmpty() &&
-                mob.getInteractingWith() != null && !mob.isLocked()) {
+                mob.getInteractingWith() == null && !mob.isLocked()) {
             wander();
         }
         return false;


### PR DESCRIPTION
## Proposed changes

Presently WanderingAction#run never returns true due to an if mob.getInteractingWith() != null . This means walking behaviors only run when there is an interaction. The opposite is wanted, walking behaviors should run when there isn't an interaction.This fixes that, by replacing with mob.getInteractingWith() == null.

## Pull Request type
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/luna-rs/luna/blob/master/CONTRIBUTING.md) doc
- [ ] Unit tests pass locally, after applying my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
None.