### PR TITLE
bugfix: CollisionMatrix.reachedFacingEntity

### DIFF
--- a/src/main/java/io/luna/game/model/collision/CollisionMatrix.java
+++ b/src/main/java/io/luna/game/model/collision/CollisionMatrix.java
@@ -585,8 +585,8 @@ public final class CollisionMatrix {
         int startY = start.getLocalY(start);
 
         Position end = target.getPosition();
-        int endX = end.getLocalX(end);
-        int endY = end.getLocalY(end);
+        int endX = end.getLocalX(start);
+        int endY = end.getLocalY(start);
 
         int radiusX = (endX + sizeX) - 1;
         int radiusY = (endY + sizeY) - 1;


### PR DESCRIPTION
## Proposed changes

Found a bug in CollisionMatrix#reachedFacingEntity where the two coordinates being compared used different references. This caused a bunch of "I can't reach" when interacting with trees and rocks, even though they are next to the player.

## Pull Request type
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/luna-rs/luna/blob/master/CONTRIBUTING.md) doc
- [ ] Unit tests pass locally, after applying my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

None.