### PR TITLE
Fix PlayerCombatContext#checkMultiCombat spamming "That player is already in combat."

### DIFF
--- a/src/main/java/io/luna/game/model/mob/combat/PlayerCombatContext.java
+++ b/src/main/java/io/luna/game/model/mob/combat/PlayerCombatContext.java
@@ -264,7 +264,7 @@ public final class PlayerCombatContext extends CombatContext {
             if (player.getCombat().inCombat() && !Objects.equals(target, other)) {
                 player.sendMessage("You are already in combat.");
                 return false;
-            } else if (other.getCombat().inCombat() && !Objects.equals(target, player)) {
+            } else if (other.getCombat().inCombat() && !Objects.equals(target, player) && !Objects.equals(other, target)) {
                 player.sendMessage("That player is already in combat.");
                 return false;
             }


### PR DESCRIPTION
## Proposed changes

During combat spam-clicking the target NPC would sometimes print the message "That player is already in combat." This proposal prevents that from happening if the newly clicked NPC is equal to the current target.

## Pull Request type

What types of changes does your code introduce to Luna?
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/luna-rs/luna/blob/master/CONTRIBUTING.md) doc
- [ ] Unit tests pass locally, after applying my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The function also has a check for if the players newly clicked target is himself. Is it really necessary to check that?