### PR TITLE
More verbosity when InteractionAction fails

### DIFF
--- a/src/main/java/io/luna/game/model/mob/interact/InteractionAction.java
+++ b/src/main/java/io/luna/game/model/mob/interact/InteractionAction.java
@@ -184,8 +184,11 @@ public final class InteractionAction extends Action<Player> {
                     event instanceof MagicOnNpcEvent || event instanceof MagicOnPlayerEvent || event instanceof PickupItemEvent;
             onReached(target instanceof Mob, instantEvent, trigger, pending);
             return true;
-        } else if (mob.getWalking().isEmpty()) {
+        } else if (mob.getWalking().isEmpty() && !listeners.isEmpty()) {
             onStanding();
+            return true;
+        } else if (listeners.isEmpty()) {
+            mob.sendMessage("No listener for "+event.getClass().getSimpleName()+"("+event.target().toString()+")");
             return true;
         }
         return false;


### PR DESCRIPTION
## Proposed changes

Currently, when InteractionAction fails, it will print "I can't reach that". I find this confusing, as it alludes to a pathing error. This PR makes it output "no listener for event <event>" when it fails due to there being no listener for the event. 

## Pull Request type
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)