### PR TITLE
Barbarians yelling YYEEEEEAAARRRRGGHHHH!!!

### DIFF
--- a/src/main/kotlin/game/game/combat/npcHooks/barbarian.kts
+++ b/src/main/kotlin/game/game/combat/npcHooks/barbarian.kts
@@ -6,12 +6,11 @@ import api.predef.*
 // Barbarians in Barbarian Village
 combat(3246, 3247, 3248, 3249, 3250, 3251, 3252, 3253, 3255, 3256, 3257, 3258, 3259, 3260, 3261, 3262, 3263) {
     attack {
-        if (npc.combat.isAttackReady) {
-            val rand = rand(36)
-            if (rand < 8) {
+        melee {
+            if (rand(36) < 8) {
                 npc.speak("YYEEEEEAAARRRRGGHHHH!!!");
             }
+            it
         }
-        melee()
     }
 }

--- a/src/main/kotlin/game/game/combat/npcHooks/barbarian.kts
+++ b/src/main/kotlin/game/game/combat/npcHooks/barbarian.kts
@@ -1,0 +1,17 @@
+package game.combat.npcHooks
+
+import api.combat.npc.NpcCombatHandler.combat
+import api.predef.*
+
+// Barbarians in Barbarian Village
+combat(3246, 3247, 3248, 3249, 3250, 3251, 3252, 3253, 3255, 3256, 3257, 3258, 3259, 3260, 3261, 3262, 3263) {
+    attack {
+        if (npc.combat.isAttackReady) {
+            val rand = rand(36)
+            if (rand < 8) {
+                npc.speak("YYEEEEEAAARRRRGGHHHH!!!");
+            }
+        }
+        melee()
+    }
+}


### PR DESCRIPTION
## Proposed changes

This adds a combat hook for barbarians in barbarian village enabling them to shout when attacking.

## Pull Request type
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Further comments

I noticed that the code inside the combat hooks attack{} will run every cycle, not just when a new attack is ready. I don't know if this is intended behavior, but it seems wasteful.