### PR TITLE
Fix bug in SecondaryHitUpdateBlock.java

### DIFF
--- a/src/main/java/io/luna/game/model/mob/block/SecondaryHitUpdateBlock.java
+++ b/src/main/java/io/luna/game/model/mob/block/SecondaryHitUpdateBlock.java
@@ -28,10 +28,10 @@ public final class SecondaryHitUpdateBlock extends UpdateBlock {
 
     @Override
     public void encodeForNpc(ByteMessage msg, UpdateBlockData data) {
-        msg.put(data.hit2.getDamage(), ValueType.ADD);
-        msg.put(data.hit2.getType().getOpcode(), ValueType.NEGATE);
-        msg.put(data.hit2.getCurrentHealth(), ValueType.ADD);
-        msg.put(data.hit2.getTotalHealth());
+        msg.put(data.hit2.getDamage(), ValueType.SUBTRACT);
+        msg.put(data.hit2.getType().getOpcode(), ValueType.SUBTRACT);
+        msg.put(data.hit2.getCurrentHealth());
+        msg.put(data.hit2.getTotalHealth(), ValueType.NEGATE);
     }
 
     @Override


### PR DESCRIPTION
## Proposed changes

Fixes crash due to wrong second hit update block for npcs.

## Pull Request type
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)