### PR TITLE
Wrong requirement when trying to equip and level too low

### DIFF
--- a/src/main/java/io/luna/game/model/def/EquipmentDefinition.java
+++ b/src/main/java/io/luna/game/model/def/EquipmentDefinition.java
@@ -39,14 +39,14 @@ public final class EquipmentDefinition implements Definition {
         private final String name;
 
         /**
-         * The internal skill id resolved from {@link #name}.
-         */
-        private final int id;
-
-        /**
          * The minimum level required.
          */
         private final int level;
+
+        /**
+         * The internal skill id resolved from {@link #name}.
+         */
+        private int id;
 
         /**
          * Creates a new {@link Requirement} from JSON data.
@@ -56,13 +56,20 @@ public final class EquipmentDefinition implements Definition {
          *     <li>{@code name}: skill name</li>
          *     <li>{@code level}: required level</li>
          * </ul>
-         *
+         * Note: This constructor is unused, as the requirements are created by gson instantiating via reflection.
          * @param jsonReq The requirement JSON object.
          */
         public Requirement(JsonObject jsonReq) {
             name = jsonReq.get("name").getAsString();
-            id = Skill.getId(name);
             level = jsonReq.get("level").getAsInt();
+            assignSkillId();
+        }
+
+        /**
+         * Assigns the internal skill identifier based on the {@link #name}.
+         */
+        public void assignSkillId() {
+            id = Skill.getId(name);
         }
 
         @Override

--- a/src/main/java/io/luna/util/parser/impl/EquipmentDefinitionFileParser.java
+++ b/src/main/java/io/luna/util/parser/impl/EquipmentDefinitionFileParser.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.nio.file.Paths;
+import java.util.Arrays;
 
 import static org.apache.logging.log4j.util.Unbox.box;
 
@@ -40,6 +41,7 @@ public final class EquipmentDefinitionFileParser extends JsonFileParser<Equipmen
         boolean fullBody = token.get("full_body?").getAsBoolean();
         boolean fullHelmet = token.get("full_helmet?").getAsBoolean();
         Requirement[] requirements = GsonUtils.getAsType(token.get("requirements"), Requirement[].class);
+        Arrays.stream(requirements).forEach(Requirement::assignSkillId);
         int[] bonuses = GsonUtils.getAsType(token.get("bonuses"), int[].class);
         return new EquipmentDefinition(id, index, twoHanded, fullBody, fullHelmet, requirements, bonuses);
     }


### PR DESCRIPTION
## Proposed changes

Currently, when trying to equip anything and the level is too low, it will say "You need an Attack level of x to equip this". This happens for example for mirror shield and rune boots, even though they don't have an attack requirement. 

This happens due to the way EquipmentDefinition is loaded. When loaded using Gson#fromJson the objects are instantiated using reflection, and so the constructor of EquipmentDefinition.Requirement is never ran. This causes the level field to never be instantiated, as this happens in the constructor. This field determines the behavior of the Requirement, so this bug is critical for equipment working properly.

This PR fixes the bug by removing final from the level field, allowing it to be instantiated in a different method, and forcibly running this method after loading. I've also added it to the unused constructor, should the way Requirements are loaded change in the future.

## Pull Request type
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Further comments

A different fix to this could be to use the streaming api in gson to load the json file. This would be a bit more verbose than the Gson#fromJson solution, but would allow "normal" instantiation of the objects, and keep the level field final.